### PR TITLE
WIP: Proof of concept for remapping internal peerDeps w/ monkey-patching

### DIFF
--- a/changes/record-changes.json
+++ b/changes/record-changes.json
@@ -1254,7 +1254,31 @@
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[5] » plugin:evelyn/jest",
+		"name": "--config#overrides[5] » plugin:evelyn/internal-peers",
+		"filePath": "CLEANED",
+		"criteria": {
+			"includes": [
+				"internal-peers"
+			],
+			"excludes": null,
+			"basePath": "CLEANED"
+		}
+	},
+	{
+		"type": "config",
+		"name": "--config#overrides[5]",
+		"filePath": "CLEANED",
+		"criteria": {
+			"includes": [
+				"internal-peers"
+			],
+			"excludes": null,
+			"basePath": "CLEANED"
+		}
+	},
+	{
+		"type": "config",
+		"name": "--config#overrides[6] » plugin:evelyn/jest",
 		"filePath": "CLEANED",
 		"criteria": {
 			"includes": [
@@ -1272,7 +1296,7 @@
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[5]",
+		"name": "--config#overrides[6]",
 		"filePath": "CLEANED",
 		"criteria": {
 			"includes": [
@@ -1284,7 +1308,7 @@
 	},
 	{
 		"type": "implicit-processor",
-		"name": "--config#overrides[6] » plugin:evelyn/json-comments » plugin:json/recommended-with-comments#processors[\"json/.json\"]",
+		"name": "--config#overrides[7] » plugin:evelyn/json-comments » plugin:json/recommended-with-comments#processors[\"json/.json\"]",
 		"filePath": "CLEANED",
 		"criteria": {
 			"AND": [
@@ -1307,7 +1331,7 @@
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[6] » plugin:evelyn/json-comments » plugin:json/recommended-with-comments",
+		"name": "--config#overrides[7] » plugin:evelyn/json-comments » plugin:json/recommended-with-comments",
 		"filePath": "CLEANED",
 		"criteria": {
 			"includes": [
@@ -1321,7 +1345,7 @@
 				"error": null,
 				"filePath": "CLEANED",
 				"id": "json",
-				"importerName": "--config#overrides[6] » plugin:evelyn/json-comments » plugin:json/recommended-with-comments",
+				"importerName": "--config#overrides[7] » plugin:evelyn/json-comments » plugin:json/recommended-with-comments",
 				"importerPath": "CLEANED"
 			}
 		},
@@ -1336,7 +1360,7 @@
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[6] » plugin:evelyn/json-comments",
+		"name": "--config#overrides[7] » plugin:evelyn/json-comments",
 		"filePath": "CLEANED",
 		"criteria": {
 			"includes": [
@@ -1348,106 +1372,13 @@
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[6] » plugin:evelyn/json-comments#overrides[0]",
+		"name": "--config#overrides[7] » plugin:evelyn/json-comments#overrides[0]",
 		"filePath": "CLEANED",
 		"criteria": {
 			"AND": [
 				{
 					"includes": [
 						"json-comments"
-					],
-					"excludes": null
-				},
-				{
-					"includes": [
-						"**/*.json"
-					],
-					"excludes": null
-				}
-			],
-			"basePath": "CLEANED"
-		}
-	},
-	{
-		"type": "config",
-		"name": "--config#overrides[6]",
-		"filePath": "CLEANED",
-		"criteria": {
-			"includes": [
-				"json-comments"
-			],
-			"excludes": null,
-			"basePath": "CLEANED"
-		}
-	},
-	{
-		"type": "implicit-processor",
-		"name": "--config#overrides[7] » plugin:evelyn/json » plugin:json/recommended#processors[\"json/.json\"]",
-		"filePath": "CLEANED",
-		"criteria": {
-			"AND": [
-				{
-					"includes": [
-						"json"
-					],
-					"excludes": null
-				},
-				{
-					"includes": [
-						"*.json"
-					],
-					"excludes": null
-				}
-			],
-			"basePath": "CLEANED"
-		},
-		"processor": "json/.json"
-	},
-	{
-		"type": "config",
-		"name": "--config#overrides[7] » plugin:evelyn/json » plugin:json/recommended",
-		"filePath": "CLEANED",
-		"criteria": {
-			"includes": [
-				"json"
-			],
-			"excludes": null,
-			"basePath": "CLEANED"
-		},
-		"plugins": {
-			"json": {
-				"error": null,
-				"filePath": "CLEANED",
-				"id": "json",
-				"importerName": "--config#overrides[7] » plugin:evelyn/json » plugin:json/recommended",
-				"importerPath": "CLEANED"
-			}
-		},
-		"rules": {
-			"json/*": "error"
-		}
-	},
-	{
-		"type": "config",
-		"name": "--config#overrides[7] » plugin:evelyn/json",
-		"filePath": "CLEANED",
-		"criteria": {
-			"includes": [
-				"json"
-			],
-			"excludes": null,
-			"basePath": "CLEANED"
-		}
-	},
-	{
-		"type": "config",
-		"name": "--config#overrides[7] » plugin:evelyn/json#overrides[0]",
-		"filePath": "CLEANED",
-		"criteria": {
-			"AND": [
-				{
-					"includes": [
-						"json"
 					],
 					"excludes": null
 				},
@@ -1467,6 +1398,65 @@
 		"filePath": "CLEANED",
 		"criteria": {
 			"includes": [
+				"json-comments"
+			],
+			"excludes": null,
+			"basePath": "CLEANED"
+		}
+	},
+	{
+		"type": "implicit-processor",
+		"name": "--config#overrides[8] » plugin:evelyn/json » plugin:json/recommended#processors[\"json/.json\"]",
+		"filePath": "CLEANED",
+		"criteria": {
+			"AND": [
+				{
+					"includes": [
+						"json"
+					],
+					"excludes": null
+				},
+				{
+					"includes": [
+						"*.json"
+					],
+					"excludes": null
+				}
+			],
+			"basePath": "CLEANED"
+		},
+		"processor": "json/.json"
+	},
+	{
+		"type": "config",
+		"name": "--config#overrides[8] » plugin:evelyn/json » plugin:json/recommended",
+		"filePath": "CLEANED",
+		"criteria": {
+			"includes": [
+				"json"
+			],
+			"excludes": null,
+			"basePath": "CLEANED"
+		},
+		"plugins": {
+			"json": {
+				"error": null,
+				"filePath": "CLEANED",
+				"id": "json",
+				"importerName": "--config#overrides[8] » plugin:evelyn/json » plugin:json/recommended",
+				"importerPath": "CLEANED"
+			}
+		},
+		"rules": {
+			"json/*": "error"
+		}
+	},
+	{
+		"type": "config",
+		"name": "--config#overrides[8] » plugin:evelyn/json",
+		"filePath": "CLEANED",
+		"criteria": {
+			"includes": [
 				"json"
 			],
 			"excludes": null,
@@ -1475,7 +1465,41 @@
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[8] » plugin:evelyn/jsx » plugin:jsx-a11y/recommended",
+		"name": "--config#overrides[8] » plugin:evelyn/json#overrides[0]",
+		"filePath": "CLEANED",
+		"criteria": {
+			"AND": [
+				{
+					"includes": [
+						"json"
+					],
+					"excludes": null
+				},
+				{
+					"includes": [
+						"**/*.json"
+					],
+					"excludes": null
+				}
+			],
+			"basePath": "CLEANED"
+		}
+	},
+	{
+		"type": "config",
+		"name": "--config#overrides[8]",
+		"filePath": "CLEANED",
+		"criteria": {
+			"includes": [
+				"json"
+			],
+			"excludes": null,
+			"basePath": "CLEANED"
+		}
+	},
+	{
+		"type": "config",
+		"name": "--config#overrides[9] » plugin:evelyn/jsx » plugin:jsx-a11y/recommended",
 		"filePath": "CLEANED",
 		"criteria": {
 			"includes": [
@@ -1494,7 +1518,7 @@
 				"error": null,
 				"filePath": "CLEANED",
 				"id": "jsx-a11y",
-				"importerName": "--config#overrides[8] » plugin:evelyn/jsx » plugin:jsx-a11y/recommended",
+				"importerName": "--config#overrides[9] » plugin:evelyn/jsx » plugin:jsx-a11y/recommended",
 				"importerPath": "CLEANED"
 			}
 		},
@@ -1680,7 +1704,7 @@
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[8] » plugin:evelyn/jsx",
+		"name": "--config#overrides[9] » plugin:evelyn/jsx",
 		"filePath": "CLEANED",
 		"criteria": {
 			"includes": [
@@ -1701,14 +1725,14 @@
 				"error": null,
 				"filePath": "CLEANED",
 				"id": "jsx-a11y",
-				"importerName": "--config#overrides[8] » plugin:evelyn/jsx",
+				"importerName": "--config#overrides[9] » plugin:evelyn/jsx",
 				"importerPath": "CLEANED"
 			}
 		}
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[8] » plugin:evelyn/jsx#overrides[0]",
+		"name": "--config#overrides[9] » plugin:evelyn/jsx#overrides[0]",
 		"filePath": "CLEANED",
 		"criteria": {
 			"AND": [
@@ -1730,7 +1754,7 @@
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[8]",
+		"name": "--config#overrides[9]",
 		"filePath": "CLEANED",
 		"criteria": {
 			"includes": [
@@ -1742,7 +1766,7 @@
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[9] » plugin:evelyn/mocha » plugin:evelyn/node » plugin:node/recommended",
+		"name": "--config#overrides[10] » plugin:evelyn/mocha » plugin:evelyn/node » plugin:node/recommended",
 		"filePath": "CLEANED",
 		"criteria": {
 			"includes": [
@@ -1814,7 +1838,7 @@
 				"error": null,
 				"filePath": "CLEANED",
 				"id": "node",
-				"importerName": "--config#overrides[9] » plugin:evelyn/mocha » plugin:evelyn/node » plugin:node/recommended",
+				"importerName": "--config#overrides[10] » plugin:evelyn/mocha » plugin:evelyn/node » plugin:node/recommended",
 				"importerPath": "CLEANED"
 			}
 		},
@@ -1843,7 +1867,7 @@
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[9] » plugin:evelyn/mocha » plugin:evelyn/node » plugin:node/recommended#overrides[0]",
+		"name": "--config#overrides[10] » plugin:evelyn/mocha » plugin:evelyn/node » plugin:node/recommended#overrides[0]",
 		"filePath": "CLEANED",
 		"criteria": {
 			"AND": [
@@ -1926,7 +1950,7 @@
 				"error": null,
 				"filePath": "CLEANED",
 				"id": "node",
-				"importerName": "--config#overrides[9] » plugin:evelyn/mocha » plugin:evelyn/node » plugin:node/recommended#overrides[0]",
+				"importerName": "--config#overrides[10] » plugin:evelyn/mocha » plugin:evelyn/node » plugin:node/recommended#overrides[0]",
 				"importerPath": "CLEANED"
 			}
 		},
@@ -1955,7 +1979,7 @@
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[9] » plugin:evelyn/mocha » plugin:evelyn/node » plugin:node/recommended#overrides[1]",
+		"name": "--config#overrides[10] » plugin:evelyn/mocha » plugin:evelyn/node » plugin:node/recommended#overrides[1]",
 		"filePath": "CLEANED",
 		"criteria": {
 			"AND": [
@@ -2038,7 +2062,7 @@
 				"error": null,
 				"filePath": "CLEANED",
 				"id": "node",
-				"importerName": "--config#overrides[9] » plugin:evelyn/mocha » plugin:evelyn/node » plugin:node/recommended#overrides[1]",
+				"importerName": "--config#overrides[10] » plugin:evelyn/mocha » plugin:evelyn/node » plugin:node/recommended#overrides[1]",
 				"importerPath": "CLEANED"
 			}
 		},
@@ -2069,7 +2093,7 @@
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[9] » plugin:evelyn/mocha » plugin:evelyn/node",
+		"name": "--config#overrides[10] » plugin:evelyn/mocha » plugin:evelyn/node",
 		"filePath": "CLEANED",
 		"criteria": {
 			"includes": [
@@ -2091,7 +2115,7 @@
 				"error": null,
 				"filePath": "CLEANED",
 				"id": "node",
-				"importerName": "--config#overrides[9] » plugin:evelyn/mocha » plugin:evelyn/node",
+				"importerName": "--config#overrides[10] » plugin:evelyn/mocha » plugin:evelyn/node",
 				"importerPath": "CLEANED"
 			}
 		},
@@ -2101,7 +2125,7 @@
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[9] » plugin:evelyn/mocha",
+		"name": "--config#overrides[10] » plugin:evelyn/mocha",
 		"filePath": "CLEANED",
 		"criteria": {
 			"includes": [
@@ -2118,14 +2142,14 @@
 				"error": null,
 				"filePath": "CLEANED",
 				"id": "mocha",
-				"importerName": "--config#overrides[9] » plugin:evelyn/mocha",
+				"importerName": "--config#overrides[10] » plugin:evelyn/mocha",
 				"importerPath": "CLEANED"
 			},
 			"node": {
 				"error": null,
 				"filePath": "CLEANED",
 				"id": "node",
-				"importerName": "--config#overrides[9] » plugin:evelyn/mocha",
+				"importerName": "--config#overrides[10] » plugin:evelyn/mocha",
 				"importerPath": "CLEANED"
 			}
 		},
@@ -2148,7 +2172,7 @@
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[9]",
+		"name": "--config#overrides[10]",
 		"filePath": "CLEANED",
 		"criteria": {
 			"includes": [
@@ -2160,7 +2184,7 @@
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[10] » plugin:evelyn/node » plugin:node/recommended",
+		"name": "--config#overrides[11] » plugin:evelyn/node » plugin:node/recommended",
 		"filePath": "CLEANED",
 		"criteria": {
 			"includes": [
@@ -2232,7 +2256,7 @@
 				"error": null,
 				"filePath": "CLEANED",
 				"id": "node",
-				"importerName": "--config#overrides[10] » plugin:evelyn/node » plugin:node/recommended",
+				"importerName": "--config#overrides[11] » plugin:evelyn/node » plugin:node/recommended",
 				"importerPath": "CLEANED"
 			}
 		},
@@ -2261,7 +2285,7 @@
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[10] » plugin:evelyn/node » plugin:node/recommended#overrides[0]",
+		"name": "--config#overrides[11] » plugin:evelyn/node » plugin:node/recommended#overrides[0]",
 		"filePath": "CLEANED",
 		"criteria": {
 			"AND": [
@@ -2344,7 +2368,7 @@
 				"error": null,
 				"filePath": "CLEANED",
 				"id": "node",
-				"importerName": "--config#overrides[10] » plugin:evelyn/node » plugin:node/recommended#overrides[0]",
+				"importerName": "--config#overrides[11] » plugin:evelyn/node » plugin:node/recommended#overrides[0]",
 				"importerPath": "CLEANED"
 			}
 		},
@@ -2373,7 +2397,7 @@
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[10] » plugin:evelyn/node » plugin:node/recommended#overrides[1]",
+		"name": "--config#overrides[11] » plugin:evelyn/node » plugin:node/recommended#overrides[1]",
 		"filePath": "CLEANED",
 		"criteria": {
 			"AND": [
@@ -2456,7 +2480,7 @@
 				"error": null,
 				"filePath": "CLEANED",
 				"id": "node",
-				"importerName": "--config#overrides[10] » plugin:evelyn/node » plugin:node/recommended#overrides[1]",
+				"importerName": "--config#overrides[11] » plugin:evelyn/node » plugin:node/recommended#overrides[1]",
 				"importerPath": "CLEANED"
 			}
 		},
@@ -2487,7 +2511,7 @@
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[10] » plugin:evelyn/node",
+		"name": "--config#overrides[11] » plugin:evelyn/node",
 		"filePath": "CLEANED",
 		"criteria": {
 			"includes": [
@@ -2509,7 +2533,7 @@
 				"error": null,
 				"filePath": "CLEANED",
 				"id": "node",
-				"importerName": "--config#overrides[10] » plugin:evelyn/node",
+				"importerName": "--config#overrides[11] » plugin:evelyn/node",
 				"importerPath": "CLEANED"
 			}
 		},
@@ -2519,7 +2543,7 @@
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[10]",
+		"name": "--config#overrides[11]",
 		"filePath": "CLEANED",
 		"criteria": {
 			"includes": [
@@ -2531,7 +2555,7 @@
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[11] » plugin:evelyn/react » plugin:evelyn/browser",
+		"name": "--config#overrides[12] » plugin:evelyn/react » plugin:evelyn/browser",
 		"filePath": "CLEANED",
 		"criteria": {
 			"includes": [
@@ -2548,7 +2572,7 @@
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[11] » plugin:evelyn/react » plugin:evelyn/jsx » plugin:jsx-a11y/recommended",
+		"name": "--config#overrides[12] » plugin:evelyn/react » plugin:evelyn/jsx » plugin:jsx-a11y/recommended",
 		"filePath": "CLEANED",
 		"criteria": {
 			"includes": [
@@ -2567,7 +2591,7 @@
 				"error": null,
 				"filePath": "CLEANED",
 				"id": "jsx-a11y",
-				"importerName": "--config#overrides[11] » plugin:evelyn/react » plugin:evelyn/jsx » plugin:jsx-a11y/recommended",
+				"importerName": "--config#overrides[12] » plugin:evelyn/react » plugin:evelyn/jsx » plugin:jsx-a11y/recommended",
 				"importerPath": "CLEANED"
 			}
 		},
@@ -2753,7 +2777,7 @@
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[11] » plugin:evelyn/react » plugin:evelyn/jsx",
+		"name": "--config#overrides[12] » plugin:evelyn/react » plugin:evelyn/jsx",
 		"filePath": "CLEANED",
 		"criteria": {
 			"includes": [
@@ -2774,14 +2798,14 @@
 				"error": null,
 				"filePath": "CLEANED",
 				"id": "jsx-a11y",
-				"importerName": "--config#overrides[11] » plugin:evelyn/react » plugin:evelyn/jsx",
+				"importerName": "--config#overrides[12] » plugin:evelyn/react » plugin:evelyn/jsx",
 				"importerPath": "CLEANED"
 			}
 		}
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[11] » plugin:evelyn/react » plugin:evelyn/jsx#overrides[0]",
+		"name": "--config#overrides[12] » plugin:evelyn/react » plugin:evelyn/jsx#overrides[0]",
 		"filePath": "CLEANED",
 		"criteria": {
 			"AND": [
@@ -2803,7 +2827,7 @@
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[11] » plugin:evelyn/react » plugin:react/recommended",
+		"name": "--config#overrides[12] » plugin:evelyn/react » plugin:react/recommended",
 		"filePath": "CLEANED",
 		"criteria": {
 			"includes": [
@@ -2822,7 +2846,7 @@
 				"error": null,
 				"filePath": "CLEANED",
 				"id": "react",
-				"importerName": "--config#overrides[11] » plugin:evelyn/react » plugin:react/recommended",
+				"importerName": "--config#overrides[12] » plugin:evelyn/react » plugin:react/recommended",
 				"importerPath": "CLEANED"
 			}
 		},
@@ -2853,7 +2877,7 @@
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[11] » plugin:evelyn/react » eslint-config-react-app",
+		"name": "--config#overrides[12] » plugin:evelyn/react » eslint-config-react-app",
 		"filePath": "CLEANED",
 		"criteria": {
 			"includes": [
@@ -2873,7 +2897,7 @@
 			"error": null,
 			"filePath": "CLEANED",
 			"id": "babel-eslint",
-			"importerName": "--config#overrides[11] » plugin:evelyn/react » eslint-config-react-app",
+			"importerName": "--config#overrides[12] » plugin:evelyn/react » eslint-config-react-app",
 			"importerPath": "CLEANED"
 		},
 		"parserOptions": {
@@ -2888,35 +2912,35 @@
 				"error": null,
 				"filePath": "CLEANED",
 				"id": "import",
-				"importerName": "--config#overrides[11] » plugin:evelyn/react » eslint-config-react-app",
+				"importerName": "--config#overrides[12] » plugin:evelyn/react » eslint-config-react-app",
 				"importerPath": "CLEANED"
 			},
 			"flowtype": {
 				"error": null,
 				"filePath": "CLEANED",
 				"id": "flowtype",
-				"importerName": "--config#overrides[11] » plugin:evelyn/react » eslint-config-react-app",
+				"importerName": "--config#overrides[12] » plugin:evelyn/react » eslint-config-react-app",
 				"importerPath": "CLEANED"
 			},
 			"jsx-a11y": {
 				"error": null,
 				"filePath": "CLEANED",
 				"id": "jsx-a11y",
-				"importerName": "--config#overrides[11] » plugin:evelyn/react » eslint-config-react-app",
+				"importerName": "--config#overrides[12] » plugin:evelyn/react » eslint-config-react-app",
 				"importerPath": "CLEANED"
 			},
 			"react": {
 				"error": null,
 				"filePath": "CLEANED",
 				"id": "react",
-				"importerName": "--config#overrides[11] » plugin:evelyn/react » eslint-config-react-app",
+				"importerName": "--config#overrides[12] » plugin:evelyn/react » eslint-config-react-app",
 				"importerPath": "CLEANED"
 			},
 			"react-hooks": {
 				"error": null,
 				"filePath": "CLEANED",
 				"id": "react-hooks",
-				"importerName": "--config#overrides[11] » plugin:evelyn/react » eslint-config-react-app",
+				"importerName": "--config#overrides[12] » plugin:evelyn/react » eslint-config-react-app",
 				"importerPath": "CLEANED"
 			}
 		},
@@ -3241,7 +3265,7 @@
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[11] » plugin:evelyn/react » eslint-config-react-app#overrides[0]",
+		"name": "--config#overrides[12] » plugin:evelyn/react » eslint-config-react-app#overrides[0]",
 		"filePath": "CLEANED",
 		"criteria": {
 			"AND": [
@@ -3264,7 +3288,7 @@
 			"error": null,
 			"filePath": "CLEANED",
 			"id": "@typescript-eslint/parser",
-			"importerName": "--config#overrides[11] » plugin:evelyn/react » eslint-config-react-app#overrides[0]",
+			"importerName": "--config#overrides[12] » plugin:evelyn/react » eslint-config-react-app#overrides[0]",
 			"importerPath": "CLEANED"
 		},
 		"parserOptions": {
@@ -3280,7 +3304,7 @@
 				"error": null,
 				"filePath": "CLEANED",
 				"id": "@typescript-eslint",
-				"importerName": "--config#overrides[11] » plugin:evelyn/react » eslint-config-react-app#overrides[0]",
+				"importerName": "--config#overrides[12] » plugin:evelyn/react » eslint-config-react-app#overrides[0]",
 				"importerPath": "CLEANED"
 			}
 		},
@@ -3324,7 +3348,7 @@
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[11] » plugin:evelyn/react",
+		"name": "--config#overrides[12] » plugin:evelyn/react",
 		"filePath": "CLEANED",
 		"criteria": {
 			"includes": [
@@ -3338,7 +3362,7 @@
 				"error": null,
 				"filePath": "CLEANED",
 				"id": "react",
-				"importerName": "--config#overrides[11] » plugin:evelyn/react",
+				"importerName": "--config#overrides[12] » plugin:evelyn/react",
 				"importerPath": "CLEANED"
 			}
 		},
@@ -3352,7 +3376,7 @@
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[11]",
+		"name": "--config#overrides[12]",
 		"filePath": "CLEANED",
 		"criteria": {
 			"includes": [
@@ -3364,7 +3388,7 @@
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[12] » plugin:evelyn/source",
+		"name": "--config#overrides[13] » plugin:evelyn/source",
 		"filePath": "CLEANED",
 		"criteria": {
 			"includes": [
@@ -3378,7 +3402,7 @@
 				"error": null,
 				"filePath": "CLEANED",
 				"id": "node",
-				"importerName": "--config#overrides[12] » plugin:evelyn/source",
+				"importerName": "--config#overrides[13] » plugin:evelyn/source",
 				"importerPath": "CLEANED"
 			}
 		},
@@ -3389,7 +3413,7 @@
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[12]",
+		"name": "--config#overrides[13]",
 		"filePath": "CLEANED",
 		"criteria": {
 			"includes": [
@@ -3401,7 +3425,7 @@
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[13] » plugin:evelyn/typescript » plugin:@typescript-eslint/eslint-recommended",
+		"name": "--config#overrides[14] » plugin:evelyn/typescript » plugin:@typescript-eslint/eslint-recommended",
 		"filePath": "CLEANED",
 		"criteria": {
 			"includes": [
@@ -3413,7 +3437,7 @@
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[13] » plugin:evelyn/typescript » plugin:@typescript-eslint/eslint-recommended#overrides[0]",
+		"name": "--config#overrides[14] » plugin:evelyn/typescript » plugin:@typescript-eslint/eslint-recommended#overrides[0]",
 		"filePath": "CLEANED",
 		"criteria": {
 			"AND": [
@@ -3449,7 +3473,7 @@
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[13] » plugin:evelyn/typescript » plugin:@typescript-eslint/recommended » ./configs/base.json",
+		"name": "--config#overrides[14] » plugin:evelyn/typescript » plugin:@typescript-eslint/recommended » ./configs/base.json",
 		"filePath": "CLEANED",
 		"criteria": {
 			"includes": [
@@ -3462,7 +3486,7 @@
 			"error": null,
 			"filePath": "CLEANED",
 			"id": "@typescript-eslint/parser",
-			"importerName": "--config#overrides[13] » plugin:evelyn/typescript » plugin:@typescript-eslint/recommended » ./configs/base.json",
+			"importerName": "--config#overrides[14] » plugin:evelyn/typescript » plugin:@typescript-eslint/recommended » ./configs/base.json",
 			"importerPath": "CLEANED"
 		},
 		"parserOptions": {
@@ -3473,14 +3497,14 @@
 				"error": null,
 				"filePath": "CLEANED",
 				"id": "@typescript-eslint",
-				"importerName": "--config#overrides[13] » plugin:evelyn/typescript » plugin:@typescript-eslint/recommended » ./configs/base.json",
+				"importerName": "--config#overrides[14] » plugin:evelyn/typescript » plugin:@typescript-eslint/recommended » ./configs/base.json",
 				"importerPath": "CLEANED"
 			}
 		}
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[13] » plugin:evelyn/typescript » plugin:@typescript-eslint/recommended",
+		"name": "--config#overrides[14] » plugin:evelyn/typescript » plugin:@typescript-eslint/recommended",
 		"filePath": "CLEANED",
 		"criteria": {
 			"includes": [
@@ -3527,7 +3551,7 @@
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[13] » plugin:evelyn/typescript » plugin:import/typescript",
+		"name": "--config#overrides[14] » plugin:evelyn/typescript » plugin:import/typescript",
 		"filePath": "CLEANED",
 		"criteria": {
 			"includes": [
@@ -3570,7 +3594,7 @@
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[13] » plugin:evelyn/typescript » plugin:@typescript-eslint/recommended-requiring-type-checking » ./configs/base.json",
+		"name": "--config#overrides[14] » plugin:evelyn/typescript » plugin:@typescript-eslint/recommended-requiring-type-checking » ./configs/base.json",
 		"filePath": "CLEANED",
 		"criteria": {
 			"includes": [
@@ -3583,7 +3607,7 @@
 			"error": null,
 			"filePath": "CLEANED",
 			"id": "@typescript-eslint/parser",
-			"importerName": "--config#overrides[13] » plugin:evelyn/typescript » plugin:@typescript-eslint/recommended-requiring-type-checking » ./configs/base.json",
+			"importerName": "--config#overrides[14] » plugin:evelyn/typescript » plugin:@typescript-eslint/recommended-requiring-type-checking » ./configs/base.json",
 			"importerPath": "CLEANED"
 		},
 		"parserOptions": {
@@ -3594,14 +3618,14 @@
 				"error": null,
 				"filePath": "CLEANED",
 				"id": "@typescript-eslint",
-				"importerName": "--config#overrides[13] » plugin:evelyn/typescript » plugin:@typescript-eslint/recommended-requiring-type-checking » ./configs/base.json",
+				"importerName": "--config#overrides[14] » plugin:evelyn/typescript » plugin:@typescript-eslint/recommended-requiring-type-checking » ./configs/base.json",
 				"importerPath": "CLEANED"
 			}
 		}
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[13] » plugin:evelyn/typescript » plugin:@typescript-eslint/recommended-requiring-type-checking",
+		"name": "--config#overrides[14] » plugin:evelyn/typescript » plugin:@typescript-eslint/recommended-requiring-type-checking",
 		"filePath": "CLEANED",
 		"criteria": {
 			"includes": [
@@ -3629,7 +3653,7 @@
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[13] » plugin:evelyn/typescript",
+		"name": "--config#overrides[14] » plugin:evelyn/typescript",
 		"filePath": "CLEANED",
 		"criteria": {
 			"includes": [
@@ -3642,7 +3666,7 @@
 			"error": null,
 			"filePath": "CLEANED",
 			"id": "@typescript-eslint/parser",
-			"importerName": "--config#overrides[13] » plugin:evelyn/typescript",
+			"importerName": "--config#overrides[14] » plugin:evelyn/typescript",
 			"importerPath": "CLEANED"
 		},
 		"parserOptions": {
@@ -3653,14 +3677,14 @@
 				"error": null,
 				"filePath": "CLEANED",
 				"id": "@typescript-eslint",
-				"importerName": "--config#overrides[13] » plugin:evelyn/typescript",
+				"importerName": "--config#overrides[14] » plugin:evelyn/typescript",
 				"importerPath": "CLEANED"
 			},
 			"node": {
 				"error": null,
 				"filePath": "CLEANED",
 				"id": "node",
-				"importerName": "--config#overrides[13] » plugin:evelyn/typescript",
+				"importerName": "--config#overrides[14] » plugin:evelyn/typescript",
 				"importerPath": "CLEANED"
 			}
 		},
@@ -3689,7 +3713,7 @@
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[13] » plugin:evelyn/typescript#overrides[0]",
+		"name": "--config#overrides[14] » plugin:evelyn/typescript#overrides[0]",
 		"filePath": "CLEANED",
 		"criteria": {
 			"AND": [
@@ -3711,7 +3735,7 @@
 	},
 	{
 		"type": "config",
-		"name": "--config#overrides[13]",
+		"name": "--config#overrides[14]",
 		"filePath": "CLEANED",
 		"criteria": {
 			"includes": [

--- a/install.js
+++ b/install.js
@@ -1,0 +1,109 @@
+const path = require("path");
+const fs = require("fs");
+const lodash = require("lodash");
+const {promisify} = require("util");
+const {CascadingConfigArrayFactory} = require("eslint/lib/cli-engine/cascading-config-array-factory");
+const factory = new CascadingConfigArrayFactory();
+const {ConfigDependency} = require("eslint/lib/cli-engine/config-array/config-dependency.js");
+
+const dirToTestFrom = process.cwd(); // TODO: Add support for overriding, installing more deeply
+const dummyFilePathToTestFrom = path.join(
+	dirToTestFrom,
+	"__placeholder__.js", // TODO: other ext configs? possible cli option --ext. How does this work with overrides? I thought it worked anyways, but need to check
+);
+const dummyConfig = require("eslint/conf/eslint-recommended.js");
+const dummyConfigResolved = require.resolve("eslint/conf/eslint-recommended.js");
+
+const ModuleResolver = require("eslint/lib/shared/relative-module-resolver");
+
+
+const originalResolve = ModuleResolver.resolve;
+ModuleResolver.resolve = function (moduleName, relativeToPath) {
+	try {
+		return originalResolve(moduleName, relativeToPath);
+	} catch (error) {
+		if (
+			typeof error === "object" &&
+			error !== null &&
+			error.code === "MODULE_NOT_FOUND" &&
+			moduleName.startsWith("eslint-config-")
+		) {
+			error.code = "_MODULE_NOT_FOUND"; // Break ESLint early throw
+			return dummyConfigResolved;
+		}
+		throw error;
+	}
+};
+
+const missingPlugins = [];
+Object.defineProperties(ConfigDependency.prototype, {
+	error: {
+		set(error) {
+			if (error && error.code === "MODULE_NOT_FOUND") {
+				const {messageData: {pluginName, configName, importerName} = {
+					pluginName: error.message.match(/Failed to load parser '([^']+)'/)[1],
+					importerName: error.message.match(/declared in '([^']+)'/)[1],
+				}} = error;
+				missingPlugins.push({
+					name: pluginName || configName,
+					importTree: importerName.split(" » "),
+				});
+			}
+			this._error = error;
+		},
+		get() {
+			return null; // eslint-disable-line unicorn/no-null
+		},
+	},
+	definition: {
+		set(definition) {
+			this._definition = definition || {
+				configs: new Proxy({}, {get: () => dummyConfig}),
+			};
+		},
+		get() {
+			return this._definition;
+		},
+	},
+	filePath: {
+		set(filePath) {
+			this._filePath = filePath || "./";
+		},
+		get() {
+			return this._filePath;
+		},
+	},
+});
+
+// start process in `dirToTestFrom`
+// only run if needed
+`npm i -D`
+
+const finalConfigArray = factory.getConfigArrayForFile(dummyFilePathToTestFrom);
+console.log(missingPlugins);
+
+
+// Promisified fs.writeFile
+const writeFile = promisify(fs.writeFile);
+
+// Turn into JSON, run predicate
+const data = JSON.stringify(
+	lodash.cloneDeepWith(
+		JSON.parse(JSON.stringify(finalConfigArray)),
+		(value, key) => ["rules"].includes(key) ? "CLEANED" : undefined
+	),
+	undefined,
+	"\t",
+) + "\n";
+
+// Save the `finalConfigArray`
+writeFile("debug_config-array.json", data, "utf8")
+	// eslint-disable-next-line no-console
+	.then(() => console.log("eslint-plugin-evelyn/save-config: Saved the config array to debug_config-array.json."))
+	.catch(error => {
+		if (error) {
+			throw new Error("eslint-plugin-evelyn/save-config: Could not save the config array to a file." + error);
+		}
+	});
+
+void(0);

--- a/lib/configs/internal-peers.js
+++ b/lib/configs/internal-peers.js
@@ -1,0 +1,25 @@
+const path = require("path");
+const ModuleResolver = require("eslint/lib/shared/relative-module-resolver");
+
+const internalModulesPath = path.resolve(
+	__dirname,
+	"../../node_modules/",
+);
+
+const originalResolve = ModuleResolver.resolve;
+ModuleResolver.resolve = function (moduleName, relativeToPath) {
+	try {
+		return originalResolve(moduleName, internalModulesPath);
+	} catch (error) {
+		if (
+			typeof error === "object" &&
+		error !== null &&
+		error.code === "MODULE_NOT_FOUND"
+		) {
+			return originalResolve(moduleName, relativeToPath);
+		}
+		throw error;
+	}
+};
+
+module.exports = {};

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,6 +5,7 @@ module.exports = {
 		"built": require("./configs/built"),
 		"default": require("./configs/default"),
 		"extensions": require("./configs/extensions"),
+		"internal-peers": require("./configs/internal-peers"),
 		"jest": require("./configs/jest"),
 		"json-comments": require("./configs/json-comments"),
 		"json": require("./configs/json"),

--- a/package.json
+++ b/package.json
@@ -48,16 +48,10 @@
     "./": "eslint"
   },
   "dependencies": {
-    "lodash": "^4.17.15"
-  },
-  "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^2.31.0",
     "@typescript-eslint/parser": "^2.31.0",
     "babel-eslint": "^10.1.0",
-    "chalk": "^4.0.0",
-    "eslint": "^7.0.0",
     "eslint-config-react-app": "^5.2.1",
-    "eslint-config-rule-tester": "^0.2.0",
     "eslint-plugin-flowtype": "^4.7.0",
     "eslint-plugin-import": "^2.20.2",
     "eslint-plugin-json": "^2.1.1",
@@ -68,28 +62,20 @@
     "eslint-plugin-react-hooks": "^4.0.0",
     "eslint-plugin-unicorn": "^19.0.1",
     "eslint-plugin-vue": "^6.2.2",
+    "lodash": "^4.17.15",
+    "typescript": "^3.8.3"
+  },
+  "devDependencies": {
+    "chalk": "^4.0.0",
+    "eslint": "^7.0.0",
+    "eslint-config-rule-tester": "^0.2.0",
     "husky": "^4.2.5",
     "lint-staged": "^10.2.2",
     "mocha": "^7.1.2",
-    "npm-run-all": "^4.1.5",
-    "typescript": "^3.8.3"
+    "npm-run-all": "^4.1.5"
   },
   "peerDependencies": {
-    "@typescript-eslint/eslint-plugin": "^2.31.0",
-    "@typescript-eslint/parser": "^2.31.0",
-    "babel-eslint": "^10.1.0",
-    "eslint": "^7.0.0",
-    "eslint-config-react-app": "^5.2.1",
-    "eslint-plugin-import": "^2.20.2",
-    "eslint-plugin-json": "^2.1.1",
-    "eslint-plugin-jsx-a11y": "^6.2.3",
-    "eslint-plugin-mocha": "^6.3.0",
-    "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-react": "^7.19.0",
-    "eslint-plugin-react-hooks": "^4.0.0",
-    "eslint-plugin-unicorn": "^19.0.1",
-    "eslint-plugin-vue": "^6.2.2",
-    "typescript": "^3.8.3"
+    "eslint": "^7.0.0"
   },
   "engines": {
     "node": "^10.12.0 || >=12.0.0"


### PR DESCRIPTION
Creating a PR specifically to document this and close it. It was fun to build for poops and giggles, but this is hella bad to merge into prod lol.

npm v7 (or possibly upcoming v6)'s will likely have optional peerDeps, and automatic installation of peers. Plus, the idea of resolving plugins relative to the config that requested it, and a few other better solutions have been in RFCS for a while.